### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ In your app `build.gradle` add the dependency to the accelerometer.
 
 ```gradle
 dependencies {
-    compile 'com.github.awareframework:com.aware.android.core:master-SNAPSHOT'
+    api 'com.github.awareframework:com.awareframework.android.core:master-SNAPSHOT'
 }
 ```
 


### PR DESCRIPTION
Changed the dependency String, as `com.aware.android.core` does not exist (should be `awareframework`, not `aware`). Also updated from `compile` to `api`, avoiding Gradle errors and bringing it inline with Gradle 3.0+.