### PR TITLE
Fixed a file generation issue regarding Room

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.library'
 
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
+apply plugin: 'kotlin-kapt'
 
 dependencies {
     testImplementation 'junit:junit:4.12'
@@ -13,7 +14,8 @@ dependencies {
 
     // ROOM
     implementation "android.arch.persistence.room:runtime:$room"
-    annotationProcessor "android.arch.persistence.room:compiler:$room"
+    // annotationProcessor "android.arch.persistence.room:compiler:$room"
+    kapt "android.arch.persistence.room:compiler:$room"
     implementation "android.arch.lifecycle:common-java8:1.1.1"
     implementation "com.commonsware.cwac:saferoom:$saferoom"
 


### PR DESCRIPTION
We need to use `kapt` insted of `annotationProcessor` for using annotation processing on Kotlin.
    
```
W/System.err: java.lang.RuntimeException: cannot find implementation for com.awareframework.android.core.db.room.AwareRoomDatabase. AwareRoomDatabase_Impl does not exist
        at androidx.room.Room.getGeneratedImplementation(Room.java:94)
        at androidx.room.RoomDatabase$Builder.build(RoomDatabase.java:667)
        at com.awareframework.android.core.db.room.AwareRoomDatabase$Companion.getInstance(AwareRoomDatabase.kt:46)
        at com.awareframework.android.core.db.RoomEngine.db(RoomEngine.kt:33)
        at com.awareframework.android.core.db.RoomEngine$save$1.invoke(RoomEngine.kt:44)
        at com.awareframework.android.core.db.RoomEngine$save$1.invoke(RoomEngine.kt:21)
W/System.err:     at kotlin.concurrent.ThreadsKt$thread$thread$1.run(Thread.kt:30)
```